### PR TITLE
Don't crash when it's impossible to remove the old root

### DIFF
--- a/eyd/src/main.rs
+++ b/eyd/src/main.rs
@@ -167,7 +167,13 @@ fn cleanup_old(root: &Path, target: &Path, retain: usize) {
                 paths.sort_by_cached_key(|x| path_file_name_to_number(x).unwrap_or(0));
                 for path in paths.iter().take(paths.len() - retain) {
                     println!("removing {}", path.display());
-                    fs::remove_dir_all(path).unwrap();
+                    if let Err(err) = fs::remove_dir_all(path) {
+                        println!(
+                            "error while removing {}, please remove manually: {:?}",
+                            path.display(),
+                            err
+                        );
+                    }
                 }
                 return;
             }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -72,6 +72,7 @@ in
           ] ++ cfg.defaultKeep ++ cfg.keep)
         }";
         RemainAfterExit = true;
+        Restart = "no";
         TimeoutSec = "infinity";
         Type = "oneshot";
       };


### PR DESCRIPTION
e.g. when there's a container with immutable `/var/empty`, see https://github.com/NixOS/nixpkgs/issues/63028